### PR TITLE
Borrower operations

### DIFF
--- a/lib/liquity/ActivePool.sol
+++ b/lib/liquity/ActivePool.sol
@@ -6,7 +6,6 @@ import './Interfaces/IActivePool.sol';
 import "./Dependencies/SafeMath.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 
 /*
  * The Active Pool holds the ETH collateral and LUSD debt (but not LUSD tokens) for all active troves.

--- a/lib/liquity/BorrowerOperations.sol
+++ b/lib/liquity/BorrowerOperations.sol
@@ -11,7 +11,6 @@ import "./Interfaces/ILQTYStaking.sol";
 import "./Dependencies/LiquityBase.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 
 contract BorrowerOperations is LiquityBase, Ownable, CheckContract, IBorrowerOperations {
     string constant public NAME = "BorrowerOperations";

--- a/lib/liquity/CollSurplusPool.sol
+++ b/lib/liquity/CollSurplusPool.sol
@@ -6,7 +6,6 @@ import "./Interfaces/ICollSurplusPool.sol";
 import "./Dependencies/SafeMath.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 
 
 contract CollSurplusPool is Ownable, CheckContract, ICollSurplusPool {

--- a/lib/liquity/DefaultPool.sol
+++ b/lib/liquity/DefaultPool.sol
@@ -6,7 +6,6 @@ import './Interfaces/IDefaultPool.sol';
 import "./Dependencies/SafeMath.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 
 /*
  * The Default Pool holds the ETH and LUSD debt (but not LUSD tokens) from liquidations that have been redistributed

--- a/lib/liquity/Dependencies/LiquityMath.sol
+++ b/lib/liquity/Dependencies/LiquityMath.sol
@@ -3,7 +3,6 @@
 pragma solidity 0.6.11;
 
 import "./SafeMath.sol";
-import "./console.sol";
 
 library LiquityMath {
     using SafeMath for uint;

--- a/lib/liquity/LPRewards/Unipool.sol
+++ b/lib/liquity/LPRewards/Unipool.sol
@@ -10,7 +10,6 @@ import "../Interfaces/ILQTYToken.sol";
 import "./Dependencies/SafeERC20.sol";
 import "./Interfaces/ILPTokenWrapper.sol";
 import "./Interfaces/IUnipool.sol";
-import "../Dependencies/console.sol";
 
 
 // Adapted from: https://github.com/Synthetixio/Unipool/blob/master/contracts/Unipool.sol

--- a/lib/liquity/LQTY/LQTYStaking.sol
+++ b/lib/liquity/LQTY/LQTYStaking.sol
@@ -6,7 +6,6 @@ import "../Dependencies/BaseMath.sol";
 import "../Dependencies/SafeMath.sol";
 import "../Dependencies/Ownable.sol";
 import "../Dependencies/CheckContract.sol";
-import "../Dependencies/console.sol";
 import "../Interfaces/ILQTYToken.sol";
 import "../Interfaces/ILQTYStaking.sol";
 import "../Dependencies/LiquityMath.sol";

--- a/lib/liquity/LQTY/LQTYToken.sol
+++ b/lib/liquity/LQTY/LQTYToken.sol
@@ -6,7 +6,6 @@ import "../Dependencies/CheckContract.sol";
 import "../Dependencies/SafeMath.sol";
 import "../Interfaces/ILQTYToken.sol";
 import "../Interfaces/ILockupContractFactory.sol";
-import "../Dependencies/console.sol";
 
 /*
 * Based upon OpenZeppelin's ERC20 contract:

--- a/lib/liquity/LQTY/LockupContractFactory.sol
+++ b/lib/liquity/LQTY/LockupContractFactory.sol
@@ -7,7 +7,6 @@ import "../Dependencies/SafeMath.sol";
 import "../Dependencies/Ownable.sol";
 import "../Interfaces/ILockupContractFactory.sol";
 import "./LockupContract.sol";
-import "../Dependencies/console.sol";
 
 /*
 * The LockupContractFactory deploys LockupContracts - its main purpose is to keep a registry of valid deployed 

--- a/lib/liquity/LUSDToken.sol
+++ b/lib/liquity/LUSDToken.sol
@@ -5,7 +5,6 @@ pragma solidity 0.6.11;
 import "./Interfaces/ILUSDToken.sol";
 import "./Dependencies/SafeMath.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 /*
 *
 * Based upon OpenZeppelin's ERC20 contract:

--- a/lib/liquity/PriceFeed.sol
+++ b/lib/liquity/PriceFeed.sol
@@ -10,7 +10,6 @@ import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
 import "./Dependencies/BaseMath.sol";
 import "./Dependencies/LiquityMath.sol";
-import "./Dependencies/console.sol";
 
 /*
 * PriceFeed for mainnet deployment, to be connected to Chainlink's live ETH:USD aggregator reference 

--- a/lib/liquity/Proxy/BorrowerWrappersScript.sol
+++ b/lib/liquity/Proxy/BorrowerWrappersScript.sol
@@ -13,7 +13,6 @@ import "../Interfaces/ILQTYStaking.sol";
 import "./BorrowerOperationsScript.sol";
 import "./ETHTransferScript.sol";
 import "./LQTYStakingScript.sol";
-import "../Dependencies/console.sol";
 
 
 contract BorrowerWrappersScript is BorrowerOperationsScript, ETHTransferScript, LQTYStakingScript {

--- a/lib/liquity/SortedTroves.sol
+++ b/lib/liquity/SortedTroves.sol
@@ -8,7 +8,6 @@ import "./Interfaces/IBorrowerOperations.sol";
 import "./Dependencies/SafeMath.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 
 /*
 * A sorted doubly linked list with nodes sorted in descending order.

--- a/lib/liquity/StabilityPool.sol
+++ b/lib/liquity/StabilityPool.sol
@@ -14,7 +14,6 @@ import "./Dependencies/SafeMath.sol";
 import "./Dependencies/LiquitySafeMath128.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 
 /*
  * The Stability Pool holds LUSD tokens deposited by Stability Pool depositors.

--- a/lib/liquity/TestContracts/EchidnaTester.sol
+++ b/lib/liquity/TestContracts/EchidnaTester.sol
@@ -13,7 +13,6 @@ import "../LUSDToken.sol";
 import "./PriceFeedTestnet.sol";
 import "../SortedTroves.sol";
 import "./EchidnaProxy.sol";
-//import "../Dependencies/console.sol";
 
 // Run with:
 // rm -f fuzzTests/corpus/* # (optional)

--- a/lib/liquity/TestContracts/MockAggregator.sol
+++ b/lib/liquity/TestContracts/MockAggregator.sol
@@ -3,7 +3,6 @@
 pragma solidity 0.6.11;
 
 import "../Dependencies/AggregatorV3Interface.sol";
-import "../Dependencies/console.sol";
 
 contract MockAggregator is AggregatorV3Interface {
     

--- a/lib/liquity/TestContracts/NonPayable.sol
+++ b/lib/liquity/TestContracts/NonPayable.sol
@@ -2,9 +2,6 @@
 
 pragma solidity 0.6.11;
 
-//import "../Dependencies/console.sol";
-
-
 contract NonPayable {
     bool isPayable;
 

--- a/lib/liquity/TroveManager.sol
+++ b/lib/liquity/TroveManager.sol
@@ -12,7 +12,6 @@ import "./Interfaces/ILQTYStaking.sol";
 import "./Dependencies/LiquityBase.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/CheckContract.sol";
-import "./Dependencies/console.sol";
 
 contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     string constant public NAME = "TroveManager";

--- a/src/BorrowerOperationsDai.sol
+++ b/src/BorrowerOperationsDai.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL3
 pragma solidity ^0.6.11;
+
 import "liquity/BorrowerOperations.sol";
 import "./StableInput/ILendingPool.sol";
 import "./StableOutput/IFeeDistributor.sol";
@@ -104,8 +105,8 @@ contract BorrowerOperationsDai is BorrowerOperations {
         // increase user's debt by _LUSDFee, giving the fee to the _feeDistributor
         _withdrawLUSD(activePool, _lusdToken, address(feeDistributor), LUSDFee, LUSDFee);
 
-        _lusdToken.approve(address(_feeDistributor), LUSDFee);
-        _feeDistributor.pushFees(LUSDFee);
+        _lusdToken.approve(address(feeDistributor), LUSDFee);
+        feeDistributor.pushFees(LUSDFee);
         return LUSDFee;
     }
 

--- a/src/BorrowerOperationsDai.sol
+++ b/src/BorrowerOperationsDai.sol
@@ -48,21 +48,66 @@ contract BorrowerOperationsDai is BorrowerOperations {
         address _feeDistributor
     )
         external
-        override
         onlyOwner
     {
-        super.setAddresses(
-            _troveManagerAddress,
-            _activePoolAddress,
-            _defaultPoolAddress,
-            _stabilityPoolAddress,
-            _gasPoolAddress,
-            _collSurplusPoolAddress,
-            _priceFeedAddress,
-            _sortedTrovesAddress,
-            _lusdTokenAddress,
-            _lqtyStakingAddress
-        );
+        /**
+         * since super.setAddresses is external we can't call it here.
+         * the next best thing is to copy-paste the code.. sadly
+         * ideally we'd call
+         * super.setAddresses(
+         *     _troveManagerAddress,
+         *     _activePoolAddress,
+         *     _defaultPoolAddress,
+         *     _stabilityPoolAddress,
+         *     _gasPoolAddress,
+         *     _collSurplusPoolAddress,
+         *     _priceFeedAddress,
+         *     _sortedTrovesAddress,
+         *     _lusdTokenAddress,
+         *     _lqtyStakingAddress
+         * );
+         */
+        
+        // BEGIN COPYPASTE
+        // This makes impossible to open a trove with zero withdrawn LUSD
+        assert(MIN_NET_DEBT > 0);
+
+        checkContract(_troveManagerAddress);
+        checkContract(_activePoolAddress);
+        checkContract(_defaultPoolAddress);
+        checkContract(_stabilityPoolAddress);
+        checkContract(_gasPoolAddress);
+        checkContract(_collSurplusPoolAddress);
+        checkContract(_priceFeedAddress);
+        checkContract(_sortedTrovesAddress);
+        checkContract(_lusdTokenAddress);
+        checkContract(_lqtyStakingAddress);
+
+        troveManager = ITroveManager(_troveManagerAddress);
+        activePool = IActivePool(_activePoolAddress);
+        defaultPool = IDefaultPool(_defaultPoolAddress);
+        stabilityPoolAddress = _stabilityPoolAddress;
+        gasPoolAddress = _gasPoolAddress;
+        collSurplusPool = ICollSurplusPool(_collSurplusPoolAddress);
+        priceFeed = IPriceFeed(_priceFeedAddress);
+        sortedTroves = ISortedTroves(_sortedTrovesAddress);
+        lusdToken = ILUSDToken(_lusdTokenAddress);
+        lqtyStakingAddress = _lqtyStakingAddress;
+        lqtyStaking = ILQTYStaking(_lqtyStakingAddress);
+
+        emit TroveManagerAddressChanged(_troveManagerAddress);
+        emit ActivePoolAddressChanged(_activePoolAddress);
+        emit DefaultPoolAddressChanged(_defaultPoolAddress);
+        emit StabilityPoolAddressChanged(_stabilityPoolAddress);
+        emit GasPoolAddressChanged(_gasPoolAddress);
+        emit CollSurplusPoolAddressChanged(_collSurplusPoolAddress);
+        emit PriceFeedAddressChanged(_priceFeedAddress);
+        emit SortedTrovesAddressChanged(_sortedTrovesAddress);
+        emit LUSDTokenAddressChanged(_lusdTokenAddress);
+        emit LQTYStakingAddressChanged(_lqtyStakingAddress);
+
+        _renounceOwnership();
+        // END COPYPASTE
 
         lendingPool = ILendingPool(_lendingPool);
         feeDistributor = IFeeDistributor(_feeDistributor);

--- a/test/BorrowerOperationsDai.t.sol
+++ b/test/BorrowerOperationsDai.t.sol
@@ -1,0 +1,114 @@
+pragma solidity ^0.6.11;
+
+import "forge-std/Test.sol";
+import "src/BorrowerOperationsDai.sol";
+import "./mocks/MockToken.sol";
+import "./mocks/MockLendingPool.sol";
+
+/**
+ * Liquity imports
+ */
+import "liquity/TroveManager.sol";
+import "liquity/ActivePool.sol";
+import "liquity/DefaultPool.sol";
+import "liquity/StabilityPool.sol";
+import "liquity/GasPool.sol";
+import "liquity/CollSurplusPool.sol";
+import "liquity/TestContracts/PriceFeedTester.sol";
+import "liquity/SortedTroves.sol";
+import "liquity/LQTY/LQTYStaking.sol";
+import "liquity/LQTY/CommunityIssuance.sol";
+
+contract BorrowerOperationsDaiTest is Test {
+    BorrowerOperationsDai public bo;
+    address public constant BORROWER = address(uint(-2));
+
+    function setUp() public {
+        // give BORROWER 1000 ETH
+        vm.deal(BORROWER, 1000e18);
+
+        MockToken token = new MockToken();
+        MockToken lqtyToken = new MockToken();
+        token.mint(address(this), 1337 * 1e18);
+        MockLendingPool lp = new MockLendingPool(token);
+        token.approve(100 * 1e18, address(lp));
+        lp.give(100 * 1e18);
+
+        bo = new BorrowerOperationsDai();
+        TroveManager tm = new TroveManager();
+        ActivePool ap = new ActivePool();
+        DefaultPool dp = new DefaultPool();
+        StabilityPool sp = new StabilityPool();
+        GasPool gp = new GasPool();
+        CollSurplusPool csp = new CollSurplusPool();
+        PriceFeedTester pf = new PriceFeedTester();
+        SortedTroves st = new SortedTroves();
+        LQTYStaking stk = new LQTYStaking();
+
+        pf.setLastGoodPrice(1000e18);
+        pf.setStatus(
+            pf.Status.chainlinkWorking
+        );
+
+        // Set addresses for all used contracts
+        // NOTE: we're using as many base LQTY contracts here as possible
+        tm.setAddresses(
+            address(bo),
+            address(ap),
+            address(dp),
+            address(sp),
+            address(gp),
+            address(csp),
+            address(pf),
+            address(token),
+            address(st),
+            address(lqtyToken),
+            address(stk)
+        );
+        ap.setAddresses(
+            address(bo),
+            address(tm),
+            address(sp),
+            address(dp)
+        );
+        dp.setAddresses(
+            address(tm),
+            address(ap)
+        );
+        sp.setAddresses(
+            address(bo),
+            address(tm),
+            address(ap),
+            address(token),
+            address(st),
+            address(pf),
+            address(ci)
+        );
+        csp.setAddresses(
+            address(bo),
+            address(tm),
+            address(ap)
+        );
+        stk.setAddresses(
+            address(lqtyToken),
+            address(token),
+            address(tm),
+            address(bo),
+            address(ap)
+        );
+        ci.setAddresses(
+            address(lqtyToken),
+            address(sp)
+        );
+    }
+
+    function testOpenTrove() public {
+        vm.prank(BORROWER);
+        bo.openTrove(
+            5,
+            1e18,
+            address(1),
+            address(0)
+        );
+    }
+}

--- a/test/mocks/MockLendingPool.sol
+++ b/test/mocks/MockLendingPool.sol
@@ -9,19 +9,19 @@ contract MockLendingPool is ILendingPool {
         token = _token;
     }
 
-    function take(uint amount) public {
+    function take(uint amount) public override {
         token.transfer(msg.sender, amount);
     }
 
-    function give(uint amount) public {
+    function give(uint amount) public override {
         token.transferFrom(msg.sender, address(this), amount);
     }
 
-    function deposit(uint amount) public {
+    function deposit(uint amount) public override {
         //noop
     }
 
-    function withdraw(uint amount) public {
+    function withdraw(uint amount) public override {
         //noop
     }
 }

--- a/test/mocks/MockLendingPool.sol
+++ b/test/mocks/MockLendingPool.sol
@@ -1,0 +1,27 @@
+pragma solidity ^0.6.11;
+
+import "src/StableInput/ILendingPool.sol";
+import "liquity/Dependencies/IERC20.sol";
+
+contract MockLendingPool is ILendingPool {
+    IERC20 public token;
+    constructor(IERC20 _token) public {
+        token = _token;
+    }
+
+    function take(uint amount) public {
+        token.transfer(msg.sender, amount);
+    }
+
+    function give(uint amount) public {
+        token.transferFrom(msg.sender, address(this), amount);
+    }
+
+    function deposit(uint amount) public {
+        //noop
+    }
+
+    function withdraw(uint amount) public {
+        //noop
+    }
+}

--- a/test/mocks/MockPriceFeed.sol
+++ b/test/mocks/MockPriceFeed.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.6.11;
+
+import "liquity/Interfaces/IPriceFeed.sol";
+
+contract MockPriceFeed is IPriceFeed {
+    uint256 private price;
+
+    function setPrice(uint256 _price) public {
+        price = _price;
+    }
+
+    function fetchPrice() public override returns (uint256) {
+        return price;
+    }
+
+    function getPrice() public view returns (uint256) {
+        return price;
+    }
+}

--- a/test/mocks/MockStaking.sol
+++ b/test/mocks/MockStaking.sol
@@ -10,32 +10,32 @@ contract MockStaking is ILQTYStaking {
         address _troveManagerAddress,
         address _borrowerOperationsAddress,
         address _activePoolAddress
-    ) public {
+    ) public override {
         //noop
     }
 
-    function stake(uint _LQTYamount) public {
+    function stake(uint _LQTYamount) public override {
         //noop
     }
 
-    function unstake(uint _LQTYamount) public {
+    function unstake(uint _LQTYamount) public override {
         //noop
     }
 
-    function increaseF_ETH(uint _ETHFee) public {
+    function increaseF_ETH(uint _ETHFee) public override {
         //noop
     }
 
-    function increaseF_LUSD(uint _LQTYFee) public {
+    function increaseF_LUSD(uint _LQTYFee) public override {
         //noop
     }
 
-    function getPendingETHGain(address _user) public view returns (uint) {
+    function getPendingETHGain(address _user) public override view returns (uint) {
         //noop
         return 0;
     }
 
-    function getPendingLUSDGain(address _user) public view returns (uint) {
+    function getPendingLUSDGain(address _user) public override view returns (uint) {
         //noop
         return 0;
     }

--- a/test/mocks/MockStaking.sol
+++ b/test/mocks/MockStaking.sol
@@ -1,0 +1,42 @@
+pragma solidity ^0.6.11;
+
+import "liquity/Interfaces/ILQTYStaking.sol";
+
+contract MockStaking is ILQTYStaking {
+    function setAddresses
+    (
+        address _lqtyTokenAddress,
+        address _lusdTokenAddress,
+        address _troveManagerAddress,
+        address _borrowerOperationsAddress,
+        address _activePoolAddress
+    ) public {
+        //noop
+    }
+
+    function stake(uint _LQTYamount) public {
+        //noop
+    }
+
+    function unstake(uint _LQTYamount) public {
+        //noop
+    }
+
+    function increaseF_ETH(uint _ETHFee) public {
+        //noop
+    }
+
+    function increaseF_LUSD(uint _LQTYFee) public {
+        //noop
+    }
+
+    function getPendingETHGain(address _user) public view returns (uint) {
+        //noop
+        return 0;
+    }
+
+    function getPendingLUSDGain(address _user) public view returns (uint) {
+        //noop
+        return 0;
+    }
+}


### PR DESCRIPTION
Adds BorrowerOperationsDai contract replacing Liquity's BorrowerOperations.
Adds tests for the new contract, using base Liquity contracts where possible.
Resolves #3 and #4.